### PR TITLE
Add legacy_layout option to MangoHud requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,5 +178,6 @@ and install it to your system.
 Put the following line in `MangoHud.conf` to have real-time latency metrics:
 
 ```
+legacy_layout=false
 graphs=custom_Latency
 ```


### PR DESCRIPTION
The graph will not show without legacy layout being disabled