### PR TITLE
AUR build fix: Use new path for vk_layer_dispatch_table.h

### DIFF
--- a/layer/latencyflex_layer.cpp
+++ b/layer/latencyflex_layer.cpp
@@ -25,7 +25,7 @@
 
 #include <dlfcn.h>
 #include <vulkan/vk_layer.h>
-#include <vulkan/vk_layer_dispatch_table.h>
+#include <vulkan/generated/vk_layer_dispatch_table.h>
 #include <vulkan/vulkan.h>
 
 #include "latencyflex.h"


### PR DESCRIPTION
`vk_layer_dispatch_table.h` was moved into the generated folder in the newest versions of `vulkan-validation-layers`.