### PR TITLE
Update Titanfall 2 link to new Northstar doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tested games:
 | Game                     | Support | Method          |
 |--------------------------|---------|-----------------|
 | Apex Legends [^1]        | ✅       | Proton NVAPI   |
-| Titanfall 2 w/ Northstar | ✅       | Proton ([Native](https://r2northstar.gitbook.io/r2northstar-wiki/using-northstar/playing-on-linux))|
+| Titanfall 2 w/ Northstar | ✅       | Proton ([Native](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/steamdeck-and-linux/installing-on-steamdeck-and-linux))|
 | Overwatch [^1]           | ✅       | Proton NVAPI   |
 | Splitgate [^3]           | ❌       | N/A            |
 | Ghostrunner              | ✅       | Proton NVAPI   |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tested games:
 | Game                     | Support | Method          |
 |--------------------------|---------|-----------------|
 | Apex Legends [^1]        | ✅       | Proton NVAPI   |
-| Titanfall 2 w/ Northstar | ✅       | Proton ([Native](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/steamdeck-and-linux/installing-on-steamdeck-and-linux))|
+| Titanfall 2 w/ Northstar | ✅       | Proton ([Native](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/steamdeck-and-linux/installing-on-steamdeck-and-linux#latencyflex))|
 | Overwatch [^1]           | ✅       | Proton NVAPI   |
 | Splitgate [^3]           | ❌       | N/A            |
 | Ghostrunner              | ✅       | Proton NVAPI   |


### PR DESCRIPTION
Old link 404s, docs moved to a new URL